### PR TITLE
feat: add command to generate LOTS of files

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ $ ACH --help
 
     import [options] [filepath] [handlebarsOptionsFile]  The file containing the JSON data to import. Defaults to "example-data.json". Then the dummy helpers JS file (optional).
     importDir [directoryPath]                            The path to the directory content to import. Defaults to "./DirectoriesToInject".
+    generateFiles [path] [filesCount]                    Create any number of small files on the Cozy.
     drop <doctypes...>                                   Deletes all documents of the provided doctypes. For real.
     export [doctypes] [filename]                         Exports data from the doctypes (separated by commas) to filename
 ```

--- a/index.js
+++ b/index.js
@@ -64,6 +64,16 @@ program.command('importDir <directoryPath>')
   })
 })
 
+program.command('generateFiles [path] [filesCount]')
+.description('Generates a given number of small files.')
+.action((path = '/', filesCount = 10) => {
+  const {url, token} = program
+  const ach = new ACH(token, url, ['io.cozy.files'])
+  ach.connect().then(() => {
+    return ach.createFiles(path, parseInt(filesCount))
+  })
+})
+
 program.command('drop <doctypes...>')
 .description('Deletes all documents of the provided doctypes. For real.')
 .action(doctypes => {

--- a/libs/ACH.js
+++ b/libs/ACH.js
@@ -1,6 +1,7 @@
 const deleteDocuments = require('./deleteDocuments')
 const dropCollections = require('./dropCollections')
 const importFolderContent = require('./importFolderContent')
+const createFiles = require('./createFiles')
 const exportData = require('./exportData')
 const getClient = require('./getClient')
 const cozyFetch = require('./cozyFetch')
@@ -58,6 +59,7 @@ const methods = {
   deleteDocuments,
   dropCollections,
   importFolder: importFolderContent,
+  createFiles,
   export: exportData,
   fetch: cozyFetch,
   updateSettings: updateSettings

--- a/libs/createFiles.js
+++ b/libs/createFiles.js
@@ -1,0 +1,20 @@
+const { uploadFile } = require('./utils')
+const randomWords = require('random-words')
+const ProgressBar = require('progress')
+
+module.exports = async (client, path, filesCount) => {
+  const { forceCreateByPath } = client.files
+  
+  const fileNames = randomWords({ exactly: filesCount })
+  
+  const bar = new ProgressBar(':bar', { total: filesCount })
+
+  for (let i = 0; i < filesCount; i++) {
+    const name = fileNames[i]
+    await forceCreateByPath(`${path}/${name}.txt`, name, {
+      name: `${name}.txt`,
+      contentType: 'text/plain'
+    })
+    bar.tick()
+  }
+}

--- a/package.json
+++ b/package.json
@@ -16,6 +16,8 @@
     "jest-diff": "^22.1.0",
     "lodash": "^4.17.4",
     "opn": "^5.1.0",
+    "progress": "^2.0.0",
+    "random-words": "^1.1.0",
     "regenerator-runtime": "0.11.0",
     "server-destroy": "^1.0.1",
     "timezone": "^1.0.13"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2122,6 +2122,10 @@ process-nextick-args@~1.0.6:
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-1.0.7.tgz#150e20b756590ad3f91093f25a4f2ad8bff30ba3"
 
+progress@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/progress/-/progress-2.0.0.tgz#8a1be366bf8fc23db2bd23f10c6fe920b4389d1f"
+
 pseudomap@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/pseudomap/-/pseudomap-1.0.2.tgz#f052a28da70e618917ef0a8ac34c1ae5a68286b3"
@@ -2141,6 +2145,10 @@ qs@~6.4.0:
 qs@~6.5.1:
   version "6.5.1"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.1.tgz#349cdf6eef89ec45c12d7d5eb3fc0c870343a6d8"
+
+random-words@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/random-words/-/random-words-1.1.0.tgz#d42f9775d14ef5c58fd255968158303e1daa0a22"
 
 randomatic@^1.1.3:
   version "1.1.7"


### PR DESCRIPTION
Usage example :  `yarn generateFiles / 1000` will spit out 1000 files at the root folder.

We need to do some perf work on drive and need LOADS of files quickly.  