### PR TITLE
🐝 fix: Defensive programming if make-token fails

### DIFF
--- a/index.js
+++ b/index.js
@@ -99,9 +99,10 @@ Type "yes" if ok.
 
 const isCommandAvailable = command => {
   try {
-    return spawnSync('which', [command], {
+    const spawned = spawnSync('which', [command], {
       stdio: 'pipe'
     })
+    return spawned.stdout.length > 0
   } catch (err) {
     return false
   }

--- a/index.js
+++ b/index.js
@@ -109,10 +109,21 @@ const isCommandAvailable = command => {
 
 const makeToken = (url, doctypes) => {
   const args= [url.replace(/https?:\/\//, ''), ...doctypes]
-  return spawnSync('make-token', args, {
+  const spawned = spawnSync('make-token', args, {
     stdio: 'pipe',
     encoding: 'utf-8'
-  }).stdout.split('\n')[0]
+  })
+  let token = null
+  if (spawned.stdout) {
+    token = spawned.stdout.split('\n')[0]
+  }
+  if (token) {
+    log.info('Made token automatically: ' + token)
+  } else {
+    log.info('Could not automatically create token')
+    log.debug(spawned.stderr)
+  }
+  return token
 }
 
 program.command('export <doctypes> <filename>')
@@ -123,7 +134,6 @@ program.command('export <doctypes> <filename>')
   let token = program.token
   if (!token && isCommandAvailable('make-token') && url.indexOf('cozy.tools') === -1) {
     token = makeToken(url, doctypes)
-    log.info('Made token automatically: ' + token)
   }
   const ach = new ACH(token, url, doctypes)
   ach.connect().then(() => {


### PR DESCRIPTION
If make-token failed, ACH export would crash. Here, if make-token fails,
the user is warned and execution continues with normal oauth flow.