### PR TITLE
feat: Output export to stdout if no filename

### DIFF
--- a/index.js
+++ b/index.js
@@ -164,7 +164,7 @@ const autotoken = (url, doctypes) => {
 }
 
 program
-  .command('export <doctypes> <filename>')
+  .command('export <doctypes> [filename]')
   .description(
     'Exports data from the doctypes (separated by commas) to filename'
   )

--- a/libs/exportData.js
+++ b/libs/exportData.js
@@ -72,7 +72,7 @@ module.exports = (cozyClient, doctypes, filename) => {
     })
     .then(data => {
       const json = JSON.stringify(data, null, 2)
-      if (filename === '-') {
+      if (filename === '-' || !filename) {
         console.log(json)
       } else {
         return writeFilePromise(filename, json)


### PR DESCRIPTION
The filename argument is now optional for the export command. If no filename is passed, output will be written to the console. This makes it easier to pipe the content of ACH into another program, for example `mint view`.