### PR TITLE
Do not use doctypes

### DIFF
--- a/libs/runBatch.js
+++ b/libs/runBatch.js
@@ -16,14 +16,14 @@ const runScriptPool = function*(script, domains, progress, dryRun) {
   let i = 0
 
   for (const domain of domains) {
-    const onResultOrError = res => {
+    const onResultOrError = (domain => res => {
       if (res instanceof Error) {
         res = { message: res.message, stack: res.stack }
       }
       i++
       console.log(JSON.stringify({ ...res, domain }))
       progress(i, domains)
-    }
+    })(domain)
     yield runScript(script, domain, dryRun).then(
       onResultOrError,
       onResultOrError

--- a/scripts/api.js
+++ b/scripts/api.js
@@ -1,7 +1,6 @@
 const mkAPI = client => {
   const api = {
     fetchAll: async doctype => {
-      console.warn('Do not use api, prefer to use cozy-doctypes')
       try {
         const result = await client.fetchJSON(
           'GET',
@@ -19,11 +18,14 @@ const mkAPI = client => {
     },
 
     updateAll: async (doctype, docs) => {
-      console.warn('Do not use api, prefer to use cozy-doctypes')
       if (!docs || docs.length === 0) {
         return []
       }
       return client.fetchJSON('POST', `/data/${doctype}/_bulk_docs`, { docs })
+    },
+
+    deleteAll: async (doctype, docs) => {
+      return api.updateAll(doctype, docs.map(x => ({ ...x, _deleted: true })))
     }
   }
 

--- a/scripts/deleteDuplicateBankAccountsWithNoOperations.js
+++ b/scripts/deleteDuplicateBankAccountsWithNoOperations.js
@@ -1,24 +1,52 @@
-const { Document, BankAccount, BankTransaction } = require('cozy-doctypes')
+const mkAPI = require('./api')
+const groupBy = require('lodash/groupBy')
+const log = require('../libs/log')
 
-const run = async dryRun => {
-  const accounts = await BankAccount.fetchAll()
-  const operations = await BankTransaction.fetchAll()
-  const accountsWithNoOperations = BankAccount.findDuplicateAccountsWithNoOperations(
+const DOCTYPE_BANK_ACCOUNTS = 'io.cozy.bank.accounts'
+const DOCTYPE_BANK_TRANSACTIONS = 'io.cozy.bank.operations'
+
+const findDuplicateAccountsWithNoOperations = (accounts, operations) => {
+  const opsByAccountId = groupBy(operations, op => op.account)
+
+  const duplicateAccountGroups = Object.entries(
+    groupBy(accounts, x => x.institutionLabel + ' > ' + x.label)
+  )
+    .map(([, group]) => group)
+    .filter(group => group.length > 1)
+
+  const res = []
+  for (const duplicateAccounts of duplicateAccountGroups) {
+    for (const account of duplicateAccounts) {
+      const accountOperations = opsByAccountId[account._id] || []
+      log.info(
+        `Account ${account._id} has ${accountOperations.length} operations`
+      )
+      if (accountOperations.length === 0) {
+        res.push(account)
+      }
+    }
+  }
+  return res
+}
+
+const run = async (api, dryRun) => {
+  const accounts = await api.fetchAll(DOCTYPE_BANK_ACCOUNTS)
+  const operations = await api.fetchAll(DOCTYPE_BANK_TRANSACTIONS)
+  const accountsWithNoOperations = findDuplicateAccountsWithNoOperations(
     accounts,
     operations
   )
   const info = {
     deletedAccounts: accountsWithNoOperations.map(x => ({
       label: x.label,
-      _id: x._id,
-      shortLabel: x.shortLabel
+      _id: x._id
     }))
   }
   try {
     if (dryRun) {
       info.dryRun = true
     } else {
-      await BankAccount.deleteAll(accountsWithNoOperations)
+      api.deleteAll(DOCTYPE_BANK_ACCOUNTS, accountsWithNoOperations)
       info.success = true
     }
   } catch (e) {
@@ -32,11 +60,11 @@ const run = async dryRun => {
 
 module.exports = {
   getDoctypes: function() {
-    return [BankAccount.doctype, BankTransaction.doctype]
+    return [DOCTYPE_BANK_ACCOUNTS, DOCTYPE_BANK_TRANSACTIONS]
   },
+  findDuplicateAccountsWithNoOperations,
   run: async function(ach, dryRun = true) {
-    Document.registerClient(ach.client)
-    return run(dryRun).catch(err => {
+    return run(mkAPI(ach.client), dryRun).catch(err => {
       return {
         error: {
           message: err.message,

--- a/scripts/deleteDuplicateBankAccountsWithNoOperations.spec.js
+++ b/scripts/deleteDuplicateBankAccountsWithNoOperations.spec.js
@@ -1,0 +1,35 @@
+const {
+  findDuplicateAccountsWithNoOperations
+} = require('./deleteDuplicateBankAccountsWithNoOperations')
+
+describe('deleteDuplicateBankAccountsWithNoOperations', () => {
+  it('should return duplicate with no operations', () => {
+    const res = findDuplicateAccountsWithNoOperations(
+      [
+        { _id: 'empty', label: 'Duplicate account', institutionLabel: 'i1' },
+        { _id: 'filled', label: 'Duplicate account', institutionLabel: 'i1' },
+        {
+          _id: 'filled_not_duplicate',
+          label: 'Account with ops',
+          institutionLabel: 'i1'
+        },
+        {
+          _id: 'duplicate_across_institution',
+          label: 'Duplicate account',
+          institutionLabel: 'i2'
+        }
+      ],
+      [
+        { _id: 'op1', account: 'filled' },
+        { _id: 'op2', account: 'filled' },
+        { _id: 'op3', account: 'filled' },
+        { _id: 'op4', account: 'filled' },
+        { _id: 'op5', account: 'filled_not_duplicate' },
+        { _id: 'op6', account: 'filled_not_duplicate' },
+        { _id: 'op7', account: 'filled_not_duplicate' }
+      ]
+    )
+
+    expect(res.map(x => x._id)).toEqual(['empty'])
+  })
+})


### PR DESCRIPTION
Since Cozy doctypes uses a global variable for its client, it cannot be used concurrently. Revert to the old method of using mkAPI.

See https://github.com/cozy/cozy-libs/pull/137