### PR TITLE
fix: Do not crash if no config file

### DIFF
--- a/libs/config.js
+++ b/libs/config.js
@@ -28,9 +28,23 @@
 
 const fs = require('fs')
 
-const config = JSON.parse(
-  fs.readFileSync(`${process.env.HOME}/.ACH.json`).toString()
-)
+const loadConfig = configPath => {
+  if (fs.existsSync(configPath)) {
+    try {
+      return JSON.parse(fs.readFileSync(configPath).toString())
+    } catch (e) {
+      console.error(
+        `Config file ${configPath} does not seem to be a valid JSON.`
+      )
+      throw new Error('Wrong config file')
+    }
+  } else {
+    return {}
+  }
+}
+
+const CONFIG_PATH = `${process.env.HOME}/.ACH.json`
+const config = loadConfig(CONFIG_PATH)
 
 const domainToEnv = {
   'cozy.wtf': 'dev',


### PR DESCRIPTION
ACH would crash if the config file was not present. Now, it does
not crash. The `batch` command will not be able to work without config
file though.