### PR TITLE
fix: Don't fail when there are no docs for a doctype

### DIFF
--- a/libs/importData.js
+++ b/libs/importData.js
@@ -189,7 +189,15 @@ const importData = async function(cozyClient, data, options) {
 
   for (let doctype of Object.keys(data)) {
     let docs = data[doctype]
-    assert(docs, 'No documents for doctype ' + doctype)
+
+    const hasDocs = docs && docs.length && docs.length > 0
+    if (!hasDocs) {
+      console.warn('No documents for doctype ' + doctype)
+      continue
+    }
+
+    console.log(`Importing ${docs.length} documents for doctype ${doctype}...`)
+
     const report = progressReport({
       doctype,
       docs,


### PR DESCRIPTION
I did the following:

* `ACH export io.cozy.bank.groups` on an instance that have no accounts for this doctype
* `ACH import goups.json`

And I got the following error:

```console
Error: Error: Must pass data, you passed undefined
    at importData (/home/drazik/.config/yarn/global/node_modules/cozy-ach/libs/importData.js:212:13)
    at <anonymous>
    at process._tickCallback (internal/process/next_tick.js:188:7)
```

So I changed a little bit the code so we don't totally crash when there is no doc for a given doctype, but print a message in the console and continue the process for the next doctype.