### PR TITLE
feat: Add removeDuplicateTransactions script

### DIFF
--- a/scripts/api.js
+++ b/scripts/api.js
@@ -25,6 +25,7 @@ const mkAPI = client => {
     },
 
     deleteAll: async (doctype, docs) => {
+      console.log('Deleting', doctype, docs.map(x => x._id))
       return api.updateAll(doctype, docs.map(x => ({ ...x, _deleted: true })))
     }
   }

--- a/scripts/banking/mergeDuplicateBankAccounts.js
+++ b/scripts/banking/mergeDuplicateBankAccounts.js
@@ -14,7 +14,12 @@ const BANK_GROUPS = 'io.cozy.bank.groups'
 
 const { matchAccounts } = require('cozy-doctypes/src/banking/matching-accounts')
 
-const strictMethods = ['originalNumber-exact', 'iban-exact', 'number-exact', 'vendorId-exact']
+const strictMethods = [
+  'originalNumber-exact',
+  'iban-exact',
+  'number-exact',
+  'vendorId-exact'
+]
 
 const isStrictMatchingMethod = method => {
   return some(strictMethods.map(sm => method.includes(sm)))

--- a/scripts/banking/mutations.js
+++ b/scripts/banking/mutations.js
@@ -1,10 +1,41 @@
-const mutations = {
-  execute: async (obj, api) => {
-    for (let doctype in obj.toUpdate) {
-      await api.updateAll(doctype, obj.toUpdate[doctype])
+const intersection = require('lodash/intersection')
+const some = require('lodash/some')
+
+const displayBulkResult = res => {
+  if (some(res, x => x.error)) {
+    for (const error of res.filter(x => x.error)) {
+      console.warn('⚠️', error)
     }
-    for (let doctype in obj.toDelete) {
-      await api.deleteAll(doctype, obj.toDelete[doctype])
+  } else {
+    console.log('✅ OK')
+  }
+}
+
+const ensureNoConflicts = mutation => {
+  for (const [doctype, updated] of Object.entries(mutation.toUpdate)) {
+    const deleted = mutation.toDelete[doctype] || []
+    const conflicts = intersection(
+      updated.map(x => x._id),
+      deleted.map(x => x._id)
+    )
+    if (conflicts.length > 0) {
+      throw new Error('Conflict detected')
+    }
+  }
+}
+
+const mutations = {
+  execute: async (mutation, api) => {
+    ensureNoConflicts(mutation)
+    for (const [doctype, docs] of Object.entries(mutation.toUpdate)) {
+      console.log('Updating', docs.length, 'documents')
+      const res = await api.updateAll(doctype, docs)
+      displayBulkResult(res)
+    }
+    for (const [doctype, docs] of Object.entries(mutation.toDelete)) {
+      console.log('Deleting', docs.length, 'documents')
+      const res = await api.deleteAll(doctype, docs)
+      displayBulkResult(res)
     }
   },
   display: mutation => {

--- a/scripts/banking/mutations.spec.js
+++ b/scripts/banking/mutations.spec.js
@@ -1,0 +1,51 @@
+const mutations = require('./mutations')
+
+const fakeDocs = _ids => _ids.map(_id => ({ _id }))
+describe('mutation', () => {
+  it('should execute a mutation', async () => {
+    const mutation = {
+      toDelete: {
+        'io.cozy.bank.operations': fakeDocs([1, 2, 3]),
+        'io.cozy.bank.accounts': fakeDocs([4, 5, 6])
+      },
+      toUpdate: {
+        'io.cozy.bank.operations': fakeDocs([7, 8, 9])
+      }
+    }
+    const fakeAPI = {
+      deleteAll: jest.fn(),
+      updateAll: jest.fn()
+    }
+    await mutations.execute(mutation, fakeAPI)
+    expect(fakeAPI.deleteAll).toHaveBeenCalledWith(
+      'io.cozy.bank.operations',
+      fakeDocs([1, 2, 3])
+    )
+    expect(fakeAPI.updateAll).toHaveBeenCalledWith(
+      'io.cozy.bank.operations',
+      fakeDocs([7, 8, 9])
+    )
+    expect(fakeAPI.deleteAll).toHaveBeenCalledWith(
+      'io.cozy.bank.accounts',
+      fakeDocs([4, 5, 6])
+    )
+  })
+  it('should detect a conflict', async () => {
+    const mutation = {
+      toDelete: {
+        'io.cozy.bank.operations': fakeDocs([1, 2, 3]),
+        'io.cozy.bank.accounts': fakeDocs([4, 5, 6])
+      },
+      toUpdate: {
+        'io.cozy.bank.operations': fakeDocs([1, 8, 9])
+      }
+    }
+    const fakeAPI = {
+      deleteAll: jest.fn(),
+      updateAll: jest.fn()
+    }
+    await expect(mutations.execute(mutation, fakeAPI)).rejects.toEqual(
+      new Error('Conflict detected')
+    )
+  })
+})

--- a/scripts/banking/removeDuplicateTransactions.js
+++ b/scripts/banking/removeDuplicateTransactions.js
@@ -1,0 +1,96 @@
+const {
+  matchTransactions
+} = require('cozy-doctypes/src/banking/matching-transactions')
+const groupBy = require('lodash/groupBy')
+const merge = require('lodash/merge')
+const mutations = require('./mutations')
+const mkAPI = require('../api')
+
+const DOCTYPE_OPERATIONS = 'io.cozy.bank.operations'
+
+const getDisplayDate = x => {
+  return (x['realisationDate'] || x['date']).substr(0, 10)
+}
+
+const isBudgetInsight = tr =>
+  tr.metadata && tr.metadata.vendor === 'budget-insight'
+
+const matchIntraDay = function*(transactions) {
+  const byDate = groupBy(transactions, getDisplayDate)
+  for (const [date, trs] of Object.entries(byDate)) {
+    const linxoOps = trs.filter(tr => !isBudgetInsight(tr))
+    const biOps = trs.filter(tr => isBudgetInsight(tr))
+    if (biOps.length === 0 || linxoOps.length === 0) {
+      continue
+    }
+    const matchedResults = matchTransactions(biOps, linxoOps)
+    for (let r of matchedResults) {
+      if (r.match) {
+        console.log(
+          '✅',
+          date,
+          r.transaction._id,
+          r.match._id,
+          r.transaction.label,
+          'matched',
+          r.match.label
+        )
+        yield r
+      } else {
+        console.log(
+          '❌ unmatched',
+          getDisplayDate(r.transaction),
+          r.transaction.label
+        )
+        console.log(linxoOps.map(x => '  ' + x.label).join('\n'))
+      }
+    }
+  }
+}
+
+const computeMutation = async api => {
+  const trs = await api.fetchAll(DOCTYPE_OPERATIONS)
+  const results = Array.from(matchIntraDay(trs))
+
+  const toDelete = []
+  const toUpdate = []
+  for (const result of results) {
+    toDelete.push(result.transaction)
+    const updatedTransaction = merge({}, result.transaction, result.match)
+    toUpdate.push(updatedTransaction)
+  }
+
+  return {
+    toDelete: {
+      'io.cozy.bank.operations': toDelete
+    },
+    toUpdate: {
+      'io.cozy.bank.operations': toUpdate
+    }
+  }
+}
+
+const run = async (api, dryRun) => {
+  const mutation = await computeMutation(api)
+  if (dryRun) {
+    mutations.display(mutation)
+  } else {
+    console.log('execute')
+    await mutations.execute(mutation, api)
+  }
+}
+
+module.exports = {
+  getDoctypes: () => [DOCTYPE_OPERATIONS],
+  run: async function(ach, dryRun = true) {
+    return run(mkAPI(ach.client), dryRun).catch(err => {
+      console.error(err)
+      return {
+        error: {
+          message: err.message,
+          stack: err.stack
+        }
+      }
+    })
+  }
+}


### PR DESCRIPTION
ACH script using the match-transaction logic from cozy-doctypes to remove duplicate transactions between BI and Linxo. Matching is done intra-day.