### PR TITLE
refactor: Move diff and logWithInstance to libs/utils

### DIFF
--- a/libs/utils.js
+++ b/libs/utils.js
@@ -1,4 +1,6 @@
 const fs = require('fs')
+const jdiff = require('jest-diff')
+
 const log = require('./log')
 
 const getContentTypeFromExtension = function(extension) {
@@ -134,4 +136,18 @@ module.exports.handleBadToken = promise => {
       throw err
     }
   })
+}
+
+module.exports.migrationDiff = (current, updated) => {
+  return jdiff(current, updated)
+    .replace('Received', 'Updated')
+    .replace('Expected', 'Current')
+}
+
+module.exports.getWithInstanceLogger = function(client) {
+  return function() {
+    const args = [].slice.call(arguments)
+    args.splice(0, 0, client._url.replace('https://', ''))
+    console.log.apply(console, args)
+  }
 }

--- a/scripts/banking/bankTransactionsAccountsMigrationV1.js
+++ b/scripts/banking/bankTransactionsAccountsMigrationV1.js
@@ -1,25 +1,16 @@
 const tz = require('timezone')
 const eu = tz(require('timezone/Europe'))
-const jdiff = require('jest-diff')
 const mkAPI = require('../api')
+const {
+  migrationDiff: diff,
+  getWithInstanceLogger
+} = require('../../libs/utils')
 
 const DOCTYPE_BANK_TRANSACTIONS = 'io.cozy.bank.operations'
 const DOCTYPE_BANK_ACCOUNTS = 'io.cozy.bank.accounts'
 const DOCTYPE_BANK_SETTINGS = 'io.cozy.bank.settings'
 
 let client, api
-
-const diff = (current, updated) => {
-  return jdiff(current, updated)
-    .replace('Received', 'Updated')
-    .replace('Expected', 'Current')
-}
-
-const logWithInstance = function() {
-  const args = [].slice.call(arguments)
-  args.splice(0, 0, client._url.replace('https://', ''))
-  console.log.apply(console, args)
-}
 
 const parisTime = date => {
   if (!date) {
@@ -56,6 +47,7 @@ const migrateAccountsV1 = docs => docs.map(migrateAccountV1)
 const migrateSettingsV1 = docs => docs.map(migrateSettingV1)
 
 const doMigrations = async dryRun => {
+  const logWithInstance = getWithInstanceLogger(client)
   const accounts = await api.fetchAll(DOCTYPE_BANK_ACCOUNTS)
   const transactions = await api.fetchAll(DOCTYPE_BANK_TRANSACTIONS)
   const settings = await api.fetchAll(DOCTYPE_BANK_SETTINGS)

--- a/scripts/banking/bankTransactionsCheckTinDate.js
+++ b/scripts/banking/bankTransactionsCheckTinDate.js
@@ -1,21 +1,12 @@
-const jdiff = require('jest-diff')
 const mkAPI = require('../api')
+const {
+  migrationDiff: diff,
+  getWithInstanceLogger
+} = require('../../libs/utils')
 
 const DOCTYPE_BANK_TRANSACTIONS = 'io.cozy.bank.operations'
 
 let client, api
-
-const diff = (current, updated) => {
-  return jdiff(current, updated)
-    .replace('Received', 'Updated')
-    .replace('Expected', 'Current')
-}
-
-const logWithInstance = function() {
-  const args = [].slice.call(arguments)
-  args.splice(0, 0, client._url.replace('https://', ''))
-  console.log.apply(console, args)
-}
 
 const removeSpaceFromDates = transaction => {
   const utransaction = { ...transaction }
@@ -27,6 +18,7 @@ const removeSpaceFromDates = transaction => {
 }
 
 const doMigrations = async dryRun => {
+  const logWithInstance = getWithInstanceLogger(client)
   const transactions = (await api.fetchAll('io.cozy.bank.operations')).filter(
     x => x.date.indexOf(' ') > -1
   )


### PR DESCRIPTION
Just moving the utils to be able to use them in contacts migration