### PR TITLE
Just display a log if there is no contacts to migrate

### DIFF
--- a/scripts/contacts/migrateContactsV1toV2.js
+++ b/scripts/contacts/migrateContactsV1toV2.js
@@ -113,8 +113,13 @@ const getAccountName = contacts => {
 }
 
 async function doMigrations(dryRun, api, logWithInstance) {
-  const accounts = await api.fetchAll(DOCTYPE_ACCOUNTS)
   const contacts = await api.fetchAll(DOCTYPE_CONTACTS)
+  if (contacts.length === 0) {
+    logWithInstance('No contacts, nothing to migrate')
+    return
+  }
+
+  const accounts = await api.fetchAll(DOCTYPE_ACCOUNTS)
   const konnectorAccount = accounts.find(doc => doc.account_type === 'google')
   const accountName = getAccountName(contacts)
 

--- a/scripts/contacts/migrateContactsV1toV2.spec.js
+++ b/scripts/contacts/migrateContactsV1toV2.spec.js
@@ -98,7 +98,7 @@ afterAll(() => {
   MockDate.reset()
 })
 
-describe('Contacts: migrate cozy metadata (konnector v1 to v2)', () => {
+describe('Contacts: migrate contacts v1 to v2', () => {
   const fakeClient = {
     fetchJSON: fetchJSONSpy
   }
@@ -115,9 +115,9 @@ describe('Contacts: migrate cozy metadata (konnector v1 to v2)', () => {
     jest.resetAllMocks()
   })
 
-  it('should migrate cozy metadata', async () => {
-    fetchJSONSpy.mockResolvedValueOnce(accountsFixture)
+  it('should migrate cozy contacts', async () => {
     fetchJSONSpy.mockResolvedValueOnce(contactsFixture)
+    fetchJSONSpy.mockResolvedValueOnce(accountsFixture)
 
     // create contact account
     fetchJSONSpy.mockResolvedValueOnce({


### PR DESCRIPTION
Avoid useless queries and possible `io.cozy.contacts.accounts` creation if there is no contact on the instance