### PR TITLE
feat(contacts): Handle contacts from multiple google accounts

### DIFF
--- a/libs/api.js
+++ b/libs/api.js
@@ -1,5 +1,19 @@
 const mkAPI = client => {
   const api = {
+    createDoctype: async doctype => {
+      try {
+        return await client.fetchJSON('PUT', `/data/${doctype}/`)
+      } catch (e) {
+        if (e.reason && e.reason.error === 'file_exists') {
+          return {
+            ok: true,
+            alreadyExists: true
+          }
+        }
+        throw e
+      }
+    },
+
     fetchAll: async doctype => {
       try {
         const result = await client.fetchJSON(

--- a/libs/api.spec.js
+++ b/libs/api.spec.js
@@ -1,0 +1,32 @@
+const mkAPI = require('./api')
+
+describe('API', () => {
+  const fetchJSONSpy = jest.fn()
+  const fakeClient = {
+    fetchJSON: fetchJSONSpy
+  }
+  const api = mkAPI(fakeClient)
+
+  afterAll(() => {
+    jest.resetAllMocks()
+  })
+
+  describe('createDoctype', () => {
+    it('should create a new doctype', async () => {
+      await api.createDoctype('io.cozy.carrots')
+      expect(fetchJSONSpy).toHaveBeenCalledWith('PUT', '/data/io.cozy.carrots/')
+    })
+
+    it('should not fail if doctype already exists', async () => {
+      fetchJSONSpy.mockRejectedValue({
+        reason: { error: 'file_exists' }
+      })
+      const result = await api.createDoctype('io.cozy.carrots')
+      expect(fetchJSONSpy).toHaveBeenCalledWith('PUT', '/data/io.cozy.carrots/')
+      expect(result).toEqual({
+        ok: true,
+        alreadyExists: true
+      })
+    })
+  })
+})


### PR DESCRIPTION
First, create a contact account for each gmail account seen in contacts metadata. Then, migrate contacts and link them to the correct contact account. We don't care about `io.cozy.accounts` anymore in this migration.