### PR TITLE
Add an option to control the pool size

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -274,13 +274,19 @@ program
   .option('-l, --limit <n>', 'Only take limit instances from the file', x =>
     parseInt(x, 10)
   )
+  .option(
+    '-p, --pool-size <n>',
+    'Limit the number of instances on which we execute the script at the same time',
+    x => parseInt(x, 10)
+  )
   .option('-x, --execute', 'Execute the script (disable dry run)')
   .description('Launch script')
   .action(async function(scriptName, domainsFile, action) {
     const script = scriptLib.require(scriptName)
     try {
       const limit = !isNaN(action.limit) ? action.limit : undefined
-      await runBatch(script, domainsFile, limit, !action.execute)
+      const poolSize = !isNaN(action.poolSize) ? action.poolSize : 30
+      await runBatch(script, domainsFile, limit, poolSize, !action.execute)
     } catch (e) {
       console.error('Error during batch execution')
       console.error(e)

--- a/libs/runBatch.js
+++ b/libs/runBatch.js
@@ -39,7 +39,7 @@ const progress = (i, arr) => {
   }
 }
 
-const runBatch = async (script, domainsFile, limit, dryRun) => {
+const runBatch = async (script, domainsFile, limit, poolSize, dryRun) => {
   const domains = fs
     .readFileSync(domainsFile)
     .toString()
@@ -54,7 +54,7 @@ const runBatch = async (script, domainsFile, limit, dryRun) => {
       progress,
       dryRun
     ),
-    30
+    poolSize
   )
   await pool.start()
   const end = new Date()


### PR DESCRIPTION
Until now, `ACH batch` runs the script on 30 instances at the same time. However, we may want to use a smaller (or bigger) pool size depending on the script to avoid that the process uses too much resources.

This PR adds an option (`-p` or `--pool-size`) that allow users to control the number of concurrency runs of their script.