### PR TITLE
Context object for ACH batch

### DIFF
--- a/libs/admin.js
+++ b/libs/admin.js
@@ -35,6 +35,9 @@ const baseFetch = (domain, route, options) => {
   })
 }
 
+/**
+ * Creates a token from the stack's admin
+ */
 const createToken = (domain, doctypes) => {
   const params = new URLSearchParams({
     Domain: domain,

--- a/libs/errors.js
+++ b/libs/errors.js
@@ -1,0 +1,10 @@
+class ChainedError extends Error {
+  constructor(message, original) {
+    super(message)
+    this.stack = original.stack + '\n' + this.stack
+  }
+}
+
+module.exports = {
+  ChainedError
+}

--- a/libs/getClient.js
+++ b/libs/getClient.js
@@ -5,11 +5,14 @@ const { addUtilityMethods } = require('./cozy-client-mixin')
 const path = require('path')
 const AppToken = cozy.auth.AppToken
 const log = require('./log')
+const { ChainedError } = require('./errors')
 const jwt = require('jsonwebtoken')
 const CLIENT_NAME = appPackage.name.toUpperCase()
 const SOFTWARE_ID = CLIENT_NAME + '-' + appPackage.version
 
 const enableDestroy = require('server-destroy')
+
+const exported = {}
 
 const revokeACHClients = (cozyClient, options) => {
   const { exclude } = options
@@ -28,7 +31,7 @@ const revokeACHClients = (cozyClient, options) => {
   })
 }
 
-const getClientWithoutToken = tokenPath => (url, docTypes = []) => {
+exported.getClientWithoutToken = tokenPath => (url, docTypes = []) => {
   let permissions = docTypes.map(docType => docType.toString() + ':ALL')
 
   // Needed for ACH revocation after execution
@@ -97,7 +100,7 @@ const onRegistered = (client, url) => {
 }
 
 // returns a client when there is already a stored token
-const getClientWithToken = tokenPath => url => {
+exported.getClientWithToken = tokenPath => url => {
   return new Promise((resolve, reject) => {
     try {
       // try to load a locally stored token and use that
@@ -117,7 +120,7 @@ const getClientWithToken = tokenPath => url => {
   })
 }
 
-const getClientWithTokenString = tokenString => async url => {
+exported.getClientWithTokenString = tokenString => async url => {
   const client = new cozy.Client()
   client.init({ cozyURL: url, token: tokenString })
   return client
@@ -125,17 +128,19 @@ const getClientWithTokenString = tokenString => async url => {
 
 // convenience wrapper around the 2 client getters
 module.exports = (tokenPath, cozyUrl, docTypes) => {
-  const absoluteTokenPath = path.resolve(tokenPath)
+  const absoluteTokenPath = tokenPath.startsWith('/')
+    ? tokenPath
+    : path.join(process.cwd(), tokenPath)
 
   let getClientFn
   if (fs.existsSync(absoluteTokenPath)) {
-    getClientFn = getClientWithToken(absoluteTokenPath)
+    getClientFn = exported.getClientWithToken(absoluteTokenPath)
   } else {
     const decoded = jwt.decode(tokenPath, { complete: true })
     if (decoded) {
-      getClientFn = getClientWithTokenString(tokenPath)
+      getClientFn = exported.getClientWithTokenString(tokenPath)
     } else {
-      getClientFn = getClientWithoutToken(absoluteTokenPath)
+      getClientFn = exported.getClientWithoutToken(absoluteTokenPath)
     }
   }
 
@@ -153,10 +158,11 @@ module.exports = (tokenPath, cozyUrl, docTypes) => {
           'No stored token found, are you sure you generated one? Use option "-t" if you want to generate one next time.'
         )
       } else {
-        console.warn(err)
-        throw new Error('Could not create client, see error above.')
+        throw new ChainedError('Could not create client', err)
       }
 
       return err
     })
 }
+
+Object.assign(module.exports, { exported })

--- a/libs/getClient.js
+++ b/libs/getClient.js
@@ -154,6 +154,7 @@ module.exports = (tokenPath, cozyUrl, docTypes) => {
         )
       } else {
         console.warn(err)
+        throw new Error('Could not create client, see error above.')
       }
 
       return err

--- a/libs/getClient.spec.js
+++ b/libs/getClient.spec.js
@@ -1,0 +1,34 @@
+const getClient = require('./getClient')
+
+jest.mock('fs', () => ({
+  existsSync: () => true
+}))
+
+describe('getClient', () => {
+  beforeEach(() => {
+    jest
+      .spyOn(getClient.exported, 'getClientWithToken')
+      .mockImplementation(() => async () => {
+        throw new Error(
+          'Could not create client with token due to unknown error'
+        )
+      })
+  })
+
+  afterEach(() => {
+    jest.restoreAllMocks()
+  })
+
+  it('should throw a chained error', async () => {
+    await expect(
+      getClient('./token-path', 'https://test.mycozy.cloud', [
+        'io.cozy.accounts'
+      ])
+    ).rejects.toMatchObject({
+      message: 'Could not create client',
+      stack: expect.stringContaining(
+        'Could not create client with token due to unknown error'
+      )
+    })
+  })
+})

--- a/libs/runBatch.js
+++ b/libs/runBatch.js
@@ -42,6 +42,7 @@ const progress = (i, arr) => {
 
 const runBatch = async ({
   script,
+  domains,
   domainsFile,
   limit,
   poolSize,
@@ -49,11 +50,18 @@ const runBatch = async ({
   fromDomain
 }) => {
   await config.loadConfig()
-  let domains = fs
-    .readFileSync(domainsFile)
-    .toString()
-    .split('\n')
-    .filter(x => x != '')
+  if (!domains && !domainsFile) {
+    throw new Error(
+      'runBatch: Invalid arguments. Need at least `domains` or `domainsFile`'
+    )
+  }
+  domains =
+    domains ||
+    fs
+      .readFileSync(domainsFile)
+      .toString()
+      .split('\n')
+      .filter(x => x != '')
 
   if (fromDomain) {
     const i = domains.findIndex(domain => domain === fromDomain)

--- a/libs/runBatch.js
+++ b/libs/runBatch.js
@@ -33,24 +33,26 @@ const runScript = async (script, domain, globalCtx) => {
   })
 }
 
+const makeResultFromError = err => ({
+  error: {
+    message: err.message,
+    stack: err.stack
+  }
+})
+
 const runScriptPool = function*(script, domains, progress, globalCtx) {
   let i = 0
 
   for (const domain of domains) {
     const onResultOrError = (domain => (type, res) => {
       if (type == 'catch') {
-        res = {
-          error: {
-            message: res.message,
-            stack: res.stack
-          }
-        }
+        res = makeResultFromError(res)
       }
-      i++
       const data = { ...res, domain }
       if (globalCtx.verbose) {
         console.log(JSON.stringify(data))
       }
+      i++
       progress(i, domains)
       return data
     })(domain)

--- a/libs/runBatch.js
+++ b/libs/runBatch.js
@@ -67,6 +67,20 @@ const progress = (i, arr) => {
   }
 }
 
+/**
+ * Reads a domain file into an Array
+ *
+ * Each domain is on 1 line
+ * Empty lines ares removed
+ */
+const readDomainFile = filename => {
+  return fs
+    .readFileSync(filename)
+    .toString()
+    .split('\n')
+    .filter(x => x != '')
+}
+
 const runBatch = async ({
   script,
   domains,
@@ -83,13 +97,7 @@ const runBatch = async ({
       'runBatch: Invalid arguments. Need at least `domains` or `domainsFile`'
     )
   }
-  domains =
-    domains ||
-    fs
-      .readFileSync(domainsFile)
-      .toString()
-      .split('\n')
-      .filter(x => x != '')
+  domains = domains || readDomainFile(domainsFile)
 
   if (fromDomain) {
     const i = domains.findIndex(domain => domain === fromDomain)

--- a/libs/runBatch.spec.js
+++ b/libs/runBatch.spec.js
@@ -1,0 +1,125 @@
+const fetch = require('node-fetch')
+global.fetch = fetch
+jest.mock('pouchdb-browser', () => () => {})
+jest.mock('./getClient', () => jest.fn())
+
+const CozyClient = require('cozy-client').default
+const getClient = require('./getClient')
+const runBatch = require('./runBatch')
+
+jest.mock('./admin', () => ({
+  createToken: jest.fn().mockReturnValue('mock-token')
+}))
+
+describe('batch', () => {
+  beforeEach(() => {
+    // Return a fake cozy-client-js
+    getClient.mockImplementation(async (token, url) => {
+      return {
+        _token: {
+          token: token
+        },
+        _url: url
+      }
+    })
+  })
+
+  const setup = () => {
+    const script = {
+      // A script that computes the reversed domain of the cozy
+      // It also counts the number of cozies
+      run: jest.fn().mockImplementation(ctx => {
+        const { client, stats } = ctx
+        stats.count = stats.count || 0
+        stats.count++
+        return {
+          reversedDomain: client.options.uri
+            .split('')
+            .reverse()
+            .join('')
+        }
+      }),
+
+      getDoctypes: () => ['io.cozy.accounts']
+    }
+    return { script }
+  }
+
+  it('should work', async () => {
+    const { script } = setup()
+    const res = await runBatch({
+      domains: [
+        'abcde.mycozy.cloud',
+        'fghij.mycozy.cloud',
+        'klmno.mycozy.cloud'
+      ],
+      script,
+      verbose: false
+    })
+
+    expect(script.run).toHaveBeenCalledTimes(3)
+    expect(script.run).toHaveBeenCalledWith({
+      client: expect.any(CozyClient),
+      dryRun: true,
+      logger: expect.any(Object),
+      stats: expect.any(Object),
+      verbose: false
+    })
+    expect(res.stats.count).toBe(3)
+    expect(res.results.map(r => r.reversedDomain)).toEqual([
+      'duolc.yzocym.edcba//:sptth',
+      'duolc.yzocym.jihgf//:sptth',
+      'duolc.yzocym.onmlk//:sptth'
+    ])
+    expect(res.results.filter(x => x.error)).toHaveLength(0)
+  })
+
+  it('should return errors', async () => {
+    const { script } = setup()
+
+    // Modify the script so that it returns an error
+    const originalRun = script.run
+    let i = -1
+    const updatedRun = function() {
+      i++
+      if (i == 1) {
+        throw new Error('Unknown error')
+      } else {
+        return originalRun.apply(this, arguments)
+      }
+    }
+    script.run = jest.fn().mockImplementation(updatedRun)
+
+    const res = await runBatch({
+      domains: [
+        'abcde.mycozy.cloud',
+        'fghij.mycozy.cloud',
+        'klmno.mycozy.cloud'
+      ],
+      script,
+      verbose: false
+    })
+
+    expect(script.run).toHaveBeenCalledTimes(3)
+    expect(script.run).toHaveBeenCalledWith({
+      client: expect.any(CozyClient),
+      dryRun: true,
+      logger: expect.any(Object),
+      stats: expect.any(Object),
+      verbose: false
+    })
+    expect(res.stats.count).toBe(2)
+    expect(
+      res.results.filter(x => !x.error).map(r => r.reversedDomain)
+    ).toEqual(['duolc.yzocym.edcba//:sptth', 'duolc.yzocym.onmlk//:sptth'])
+    expect(res.results.filter(x => x.error)).toEqual([
+      {
+        domain: 'fghij.mycozy.cloud',
+        error: {
+          message: 'Unknown error',
+          stack: expect.any(String)
+        }
+      }
+    ])
+  })
+})

--- a/libs/runBatch.spec.js
+++ b/libs/runBatch.spec.js
@@ -59,7 +59,7 @@ describe('batch', () => {
         'klmno.mycozy.cloud'
       ],
       script,
-      verbose: false
+      logResults: false
     })
 
     expect(script.run).toHaveBeenCalledTimes(3)
@@ -67,8 +67,7 @@ describe('batch', () => {
       client: expect.any(CozyClient),
       dryRun: true,
       logger: expect.any(Object),
-      stats: expect.any(Object),
-      verbose: false
+      stats: expect.any(Object)
     })
     expect(res.stats.count).toBe(3)
     expect(res.results.map(r => r.reversedDomain)).toEqual([
@@ -102,7 +101,7 @@ describe('batch', () => {
         'klmno.mycozy.cloud'
       ],
       script,
-      verbose: false
+      logResults: false
     })
 
     expect(script.run).toHaveBeenCalledTimes(3)
@@ -110,8 +109,7 @@ describe('batch', () => {
       client: expect.any(CozyClient),
       dryRun: true,
       logger: expect.any(Object),
-      stats: expect.any(Object),
-      verbose: false
+      stats: expect.any(Object)
     })
     expect(res.stats.count).toBe(2)
     expect(

--- a/libs/runBatch.spec.js
+++ b/libs/runBatch.spec.js
@@ -11,6 +11,11 @@ jest.mock('./admin', () => ({
   createToken: jest.fn().mockReturnValue('mock-token')
 }))
 
+jest.mock('./config', () => ({
+  loadConfig: () => {},
+  getAdminConfigForDomain: () => {}
+}))
+
 describe('batch', () => {
   beforeEach(() => {
     // Return a fake cozy-client-js

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "colors": "^1.3.3",
     "commander": "^2.19.0",
     "core-js": "3.0.0",
+    "cozy-client": "6.64.5",
     "cozy-client-js": "^0.15.0",
     "cozy-doctypes": "1.39.0",
     "directory-tree": "^2.2.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -632,6 +632,13 @@
   dependencies:
     regenerator-runtime "^0.12.0"
 
+"@babel/runtime@^7.1.2":
+  version "7.6.0"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.6.0.tgz#4fc1d642a9fd0299754e8b5de62c631cf5568205"
+  integrity sha512-89eSBLJsxNxOERC0Op4vd+0Bqm6wRMqMbFtV3i0/fbaWw/mJ8Q3eBvgX0G4SyrOOLCtbu98HspF8o09MRT+KzQ==
+  dependencies:
+    regenerator-runtime "^0.13.2"
+
 "@babel/template@^7.1.0", "@babel/template@^7.4.4":
   version "7.4.4"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.4.4.tgz#f4b88d1225689a08f5bc3a17483545be9e4ed237"
@@ -2088,6 +2095,29 @@ cozy-client-js@^0.15.0:
     pouchdb-browser "7.0.0"
     pouchdb-find "7.0.0"
 
+cozy-client@6.64.5:
+  version "6.64.5"
+  resolved "https://registry.yarnpkg.com/cozy-client/-/cozy-client-6.64.5.tgz#33302c3190387ad42928189ae916f5afb28c3a84"
+  integrity sha512-DnlNaYNTeTAuIAGeKggQbGW/a9CUl19Ec9IdUzBlzkeylAkBvdfbyIg6BTzXePdae0o+bGh0LV9VAJ5yX4C2YA==
+  dependencies:
+    cozy-device-helper "^1.7.3"
+    cozy-stack-client "^6.64.3"
+    lodash "^4.17.13"
+    microee "^0.0.6"
+    prop-types "^15.6.2"
+    react-redux "^5.0.7"
+    redux "^3.7.2"
+    redux-thunk "^2.3.0"
+    sift "^6.0.0"
+    url-search-params-polyfill "^7.0.0"
+
+cozy-device-helper@^1.7.3:
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/cozy-device-helper/-/cozy-device-helper-1.8.0.tgz#17b41d0ea28a504b906669a43449952e72615abb"
+  integrity sha512-XomsjdCCWcS01x1QK/Wc4EI4zTxJN8Ouh7956wm2AEQyjj4lN+7cj8tqEBlb8fLWm68/3S3Z4V3iSJDgnJHu6A==
+  dependencies:
+    lodash "4.17.15"
+
 cozy-doctypes@1.39.0:
   version "1.39.0"
   resolved "https://registry.yarnpkg.com/cozy-doctypes/-/cozy-doctypes-1.39.0.tgz#edbd8b7575d858ce5305c0e7c6d14cf6c44b6d83"
@@ -2104,6 +2134,15 @@ cozy-logger@1.3.1:
   integrity sha512-oa2h6wkLuCTucUeeFQKOYE0hGtP6VZ+tRMxV/MKqIRKMq8xngareUusQX03jXP3C+O1GeaEhSmaboHlIDJnH7A==
   dependencies:
     json-stringify-safe "5.0.1"
+
+cozy-stack-client@^6.64.3:
+  version "6.64.3"
+  resolved "https://registry.yarnpkg.com/cozy-stack-client/-/cozy-stack-client-6.64.3.tgz#535bcc18646ea729b9c531b56d2b915b86c568db"
+  integrity sha512-cee/8od9KCT7IMxhjp64fGkwfCGgGGZ2Z0tOVDIfO6ztjjzx0U3gD0UzVf1cN3kk3JFud/K50AqLtpOpa+1R4g==
+  dependencies:
+    detect-node "^2.0.4"
+    mime "^2.4.0"
+    qs "^6.7.0"
 
 create-error-class@^3.0.0:
   version "3.0.2"
@@ -2210,7 +2249,7 @@ debug@^4.0.0, debug@^4.0.1, debug@^4.1.0:
   dependencies:
     ms "^2.1.1"
 
-debuglog@*, debuglog@^1.0.1:
+debuglog@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/debuglog/-/debuglog-1.0.1.tgz#aa24ffb9ac3df9a2351837cfb2d279360cd78492"
   integrity sha1-qiT/uaw9+aI1GDfPstJ5NgzXhJI=
@@ -2339,6 +2378,11 @@ detect-newline@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/detect-newline/-/detect-newline-2.1.0.tgz#f41f1c10be4b00e87b5f13da680759f2c5bfd3e2"
   integrity sha1-9B8cEL5LAOh7XxPaaAdZ8sW/0+I=
+
+detect-node@^2.0.4:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/detect-node/-/detect-node-2.0.4.tgz#014ee8f8f669c5c58023da64b8179c083a28c46c"
+  integrity sha512-ZIzRpLJrOj7jjP2miAtgqIfmzbxa4ZOr5jJc601zklsfEx9oTzmmj2nVpIPRpNlRTIh8lc1kyViIY7BWSGNmKw==
 
 dezalgo@^1.0.0, dezalgo@~1.0.3:
   version "1.0.3"
@@ -3562,6 +3606,13 @@ has@^1.0.1, has@^1.0.3:
   dependencies:
     function-bind "^1.1.1"
 
+hoist-non-react-statics@^3.1.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-3.3.0.tgz#b09178f0122184fb95acf525daaecb4d8f45958b"
+  integrity sha512-0XsbTXxgiaCDYDIWFcwkmerZPSwywfUqYmwT4jzewKTQSWoE6FCMoUVOeBJWK3E/CrWbxRG3m5GzY4lnIwGRBA==
+  dependencies:
+    react-is "^16.7.0"
+
 home-or-tmp@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/home-or-tmp/-/home-or-tmp-2.0.0.tgz#e36c3f2d2cae7d746a857e38d18d5f32a7882db8"
@@ -3711,7 +3762,7 @@ import-local@^1.0.0:
     pkg-dir "^2.0.0"
     resolve-cwd "^2.0.0"
 
-imurmurhash@*, imurmurhash@^0.1.4:
+imurmurhash@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/imurmurhash/-/imurmurhash-0.1.4.tgz#9218b9b2b928a238b13dc4fb6b6d576f231453ea"
   integrity sha1-khi5srkoojixPcT7a21XbyMUU+o=
@@ -5044,10 +5095,10 @@ lockfile@^1.0.4:
   dependencies:
     signal-exit "^3.0.2"
 
-lodash._baseindexof@*:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/lodash._baseindexof/-/lodash._baseindexof-3.1.0.tgz#fe52b53a1c6761e42618d654e4a25789ed61822c"
-  integrity sha1-/lK1OhxnYeQmGNZU5KJXie1hgiw=
+lodash-es@^4.2.1:
+  version "4.17.15"
+  resolved "https://registry.yarnpkg.com/lodash-es/-/lodash-es-4.17.15.tgz#21bd96839354412f23d7a10340e5eac6ee455d78"
+  integrity sha512-rlrc3yU3+JNOpZ9zj5pQtxnx2THmvRykwL4Xlxoa8I9lHBlVbbyPhgyPMioxVZ4NqyxaVVtaJnzsyOidQIhyyQ==
 
 lodash._baseuniq@~4.6.0:
   version "4.6.0"
@@ -5057,32 +5108,10 @@ lodash._baseuniq@~4.6.0:
     lodash._createset "~4.0.0"
     lodash._root "~3.0.0"
 
-lodash._bindcallback@*:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz#e531c27644cf8b57a99e17ed95b35c748789392e"
-  integrity sha1-5THCdkTPi1epnhftlbNcdIeJOS4=
-
-lodash._cacheindexof@*:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/lodash._cacheindexof/-/lodash._cacheindexof-3.0.2.tgz#3dc69ac82498d2ee5e3ce56091bafd2adc7bde92"
-  integrity sha1-PcaayCSY0u5ePOVgkbr9Ktx73pI=
-
-lodash._createcache@*:
-  version "3.1.2"
-  resolved "https://registry.yarnpkg.com/lodash._createcache/-/lodash._createcache-3.1.2.tgz#56d6a064017625e79ebca6b8018e17440bdcf093"
-  integrity sha1-VtagZAF2JeeevKa4AY4XRAvc8JM=
-  dependencies:
-    lodash._getnative "^3.0.0"
-
 lodash._createset@~4.0.0:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/lodash._createset/-/lodash._createset-4.0.3.tgz#0f4659fbb09d75194fa9e2b88a6644d363c9fe26"
   integrity sha1-D0ZZ+7CddRlPqeK4imZE02PJ/iY=
-
-lodash._getnative@*, lodash._getnative@^3.0.0:
-  version "3.9.1"
-  resolved "https://registry.yarnpkg.com/lodash._getnative/-/lodash._getnative-3.9.1.tgz#570bc7dede46d61cdcde687d65d3eecbaa3aaff5"
-  integrity sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U=
 
 lodash._root@~3.0.0:
   version "3.0.1"
@@ -5149,11 +5178,6 @@ lodash.once@^4.0.0:
   resolved "https://registry.yarnpkg.com/lodash.once/-/lodash.once-4.1.1.tgz#0dd3971213c7c56df880977d504c88fb471a97ac"
   integrity sha1-DdOXEhPHxW34gJd9UEyI+0cal6w=
 
-lodash.restparam@*:
-  version "3.6.1"
-  resolved "https://registry.yarnpkg.com/lodash.restparam/-/lodash.restparam-3.6.1.tgz#936a4e309ef330a7645ed4145986c85ae5b20805"
-  integrity sha1-k2pOMJ7zMKdkXtQUWYbIWuWyCAU=
-
 lodash.set@^4.3.2:
   version "4.3.2"
   resolved "https://registry.yarnpkg.com/lodash.set/-/lodash.set-4.3.2.tgz#d8757b1da807dde24816b0d6a84bea1a76230b23"
@@ -5194,12 +5218,12 @@ lodash@4.17.11:
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.11.tgz#b39ea6229ef607ecd89e2c8df12536891cac9b8d"
   integrity sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==
 
-lodash@^4.17.11, lodash@^4.17.12, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.4, lodash@^4.2.1:
+lodash@4.17.15, lodash@^4.17.11, lodash@^4.17.12, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.4, lodash@^4.2.1:
   version "4.17.15"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
   integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==
 
-loose-envify@^1.0.0, loose-envify@^1.4.0:
+loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.4.0.tgz#71ee51fa7be4caec1a63839f7e682d8132d30caf"
   integrity sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==
@@ -5392,6 +5416,11 @@ merge@^1.2.0:
   resolved "https://registry.yarnpkg.com/merge/-/merge-1.2.1.tgz#38bebf80c3220a8a487b6fcfb3941bb11720c145"
   integrity sha512-VjFo4P5Whtj4vsLzsYBu5ayHhoHJ0UqNm7ibvShmbmoz7tGi0vXaoJbGdB+GmDMLUdg8DpQXEIeVDAe8MaABvQ==
 
+microee@^0.0.6:
+  version "0.0.6"
+  resolved "https://registry.yarnpkg.com/microee/-/microee-0.0.6.tgz#a12bdb0103681e8b126a9b071eba4c467c78fffe"
+  integrity sha1-oSvbAQNoHosSapsHHrpMRnx4//4=
+
 micromatch@^2.3.11:
   version "2.3.11"
   resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-2.3.11.tgz#86677c97d1720b363431d04d0d15293bd38c1565"
@@ -5450,7 +5479,7 @@ mime-types@^2.1.12, mime-types@~2.1.19:
   dependencies:
     mime-db "1.40.0"
 
-mime@^2.4.3:
+mime@^2.4.0, mime@^2.4.3:
   version "2.4.4"
   resolved "https://registry.yarnpkg.com/mime/-/mime-2.4.4.tgz#bd7b91135fc6b01cde3e9bae33d659b63d8857e5"
   integrity sha512-LRxmNwziLPT828z+4YkNzloCFC2YM4wrB99k+AV5ZbEyfGNWfG8SO1FUXLmLDBSo89NrJZ4DIWeLjy1CHGhMGA==
@@ -6760,7 +6789,7 @@ promzard@^0.3.0:
   dependencies:
     read "1"
 
-prop-types@^15.6.2:
+prop-types@^15.6.1, prop-types@^15.6.2:
   version "15.7.2"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.7.2.tgz#52c41e75b8c87e72b9d9360e0206b99dcbffa6c5"
   integrity sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==
@@ -6841,6 +6870,11 @@ qrcode-terminal@^0.12.0:
   resolved "https://registry.yarnpkg.com/qrcode-terminal/-/qrcode-terminal-0.12.0.tgz#bb5b699ef7f9f0505092a3748be4464fe71b5819"
   integrity sha512-EXtzRZmC+YGmGlDFbXKxQiMZNwCLEO6BANKXG4iCtSIM0yqc/pappSx3RIKr4r0uh5JsBckOXeKrB3Iz7mdQpQ==
 
+qs@^6.7.0:
+  version "6.8.0"
+  resolved "https://registry.yarnpkg.com/qs/-/qs-6.8.0.tgz#87b763f0d37ca54200334cd57bb2ef8f68a1d081"
+  integrity sha512-tPSkj8y92PfZVbinY1n84i1Qdx75lZjMQYx9WZhnkofyxzw2r7Ho39G3/aEvSUdebxpnnM4LZJCtvE/Aq3+s9w==
+
 qs@~6.5.2:
   version "6.5.2"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.2.tgz#cb3ae806e8740444584ef154ce8ee98d403f3e36"
@@ -6889,10 +6923,28 @@ rc@^1.0.1, rc@^1.1.6, rc@^1.2.7, rc@^1.2.8:
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
 
-react-is@^16.8.1, react-is@^16.8.4:
+react-is@^16.6.0, react-is@^16.7.0, react-is@^16.8.1, react-is@^16.8.4:
   version "16.9.0"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.9.0.tgz#21ca9561399aad0ff1a7701c01683e8ca981edcb"
   integrity sha512-tJBzzzIgnnRfEm046qRcURvwQnZVXmuCbscxUO5RWrGTXpon2d4c8mI0D8WE6ydVIm29JiLB6+RslkIvym9Rjw==
+
+react-lifecycles-compat@^3.0.0:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz#4f1a273afdfc8f3488a8c516bfda78f872352362"
+  integrity sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==
+
+react-redux@^5.0.7:
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/react-redux/-/react-redux-5.1.1.tgz#88e368682c7fa80e34e055cd7ac56f5936b0f52f"
+  integrity sha512-LE7Ned+cv5qe7tMV5BPYkGQ5Lpg8gzgItK07c67yHvJ8t0iaD9kPFPAli/mYkiyJYrs2pJgExR2ZgsGqlrOApg==
+  dependencies:
+    "@babel/runtime" "^7.1.2"
+    hoist-non-react-statics "^3.1.0"
+    invariant "^2.2.4"
+    loose-envify "^1.1.0"
+    prop-types "^15.6.1"
+    react-is "^16.6.0"
+    react-lifecycles-compat "^3.0.0"
 
 read-cmd-shim@^1.0.1, read-cmd-shim@^1.0.3:
   version "1.0.4"
@@ -7059,6 +7111,21 @@ redeyed@~2.1.0:
   integrity sha1-iYS1gV2ZyyIEacme7v/jiRPmzAs=
   dependencies:
     esprima "~4.0.0"
+
+redux-thunk@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/redux-thunk/-/redux-thunk-2.3.0.tgz#51c2c19a185ed5187aaa9a2d08b666d0d6467622"
+  integrity sha512-km6dclyFnmcvxhAcrQV2AkZmPQjzPDjgVlQtR0EQjxZPyJ0BnMf3in1ryuR8A2qU0HldVRfxYXbFSKlI3N7Slw==
+
+redux@^3.7.2:
+  version "3.7.2"
+  resolved "https://registry.yarnpkg.com/redux/-/redux-3.7.2.tgz#06b73123215901d25d065be342eb026bc1c8537b"
+  integrity sha512-pNqnf9q1hI5HHZRBkj3bAngGZW/JMCmexDlOxw4XagXY2o1327nHH54LoTjiPJ0gizoqPDRqWyX/00g0hD6w+A==
+  dependencies:
+    lodash "^4.2.1"
+    lodash-es "^4.2.1"
+    loose-envify "^1.1.0"
+    symbol-observable "^1.0.3"
 
 regenerate-unicode-properties@^8.1.0:
   version "8.1.0"
@@ -7520,6 +7587,11 @@ shellwords@^0.1.1:
   resolved "https://registry.yarnpkg.com/shellwords/-/shellwords-0.1.1.tgz#d6b9181c1a48d397324c84871efbcfc73fc0654b"
   integrity sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==
 
+sift@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/sift/-/sift-6.0.0.tgz#f93a778e5cbf05a5024ebc391e6b32511a6d1f82"
+  integrity sha1-+Tp3jly/BaUCTrw5HmsyURptH4I=
+
 signal-exit@^3.0.0, signal-exit@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.2.tgz#b5fdc08f1287ea1178628e415e25132b73646c6d"
@@ -7954,6 +8026,11 @@ supports-hyperlinks@^1.0.1:
     has-flag "^2.0.0"
     supports-color "^5.0.0"
 
+symbol-observable@^1.0.3:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-1.2.0.tgz#c22688aed4eab3cdc2dfeacbb561660560a00804"
+  integrity sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ==
+
 symbol-tree@^3.2.2:
   version "3.2.4"
   resolved "https://registry.yarnpkg.com/symbol-tree/-/symbol-tree-3.2.4.tgz#430637d248ba77e078883951fb9aa0eed7c63fa2"
@@ -8357,6 +8434,11 @@ url-parse-lax@^3.0.0:
   integrity sha1-FrXK/Afb42dsGxmZF3gj1lA6yww=
   dependencies:
     prepend-http "^2.0.0"
+
+url-search-params-polyfill@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/url-search-params-polyfill/-/url-search-params-polyfill-7.0.0.tgz#98b56ed29e67710588fdc3c361083b0f78303d95"
+  integrity sha512-0SEH3s+wCNbxEE/rWUalN004ICNi23Q74Ksc0gS2kG8EXnbayxGOrV97JdwnIVPKZ75Xk0hvKXvtIC4xReLMgg==
 
 url-template@^2.0.8:
   version "2.0.8"


### PR DESCRIPTION
Instead of passing several arguments in the run() function, we receive one
context object containing :

- client: a new cozy-client
- dryRun: whether we've been run with the dryRun flag
- logger: a proxy for console methods that adds the domain of the current cozy
- stats: an object where to store useful statistics

Additionally, the `runBatch` now resolves with its results.

```
runBatch(...).then(({ results, stats }) => {
  reportStats(stats)
  reportResults(results)
})
```

The user is for now responsible to report the errors in the results. Errors
have the `error` attribute whereas normal results do not have it.