### PR TITLE
fix: Import works with handlebars templates

### DIFF
--- a/libs/getHandlebarsOptions.js
+++ b/libs/getHandlebarsOptions.js
@@ -1,0 +1,69 @@
+const { merge, once } = require('lodash')
+const log = require('./log')
+const Handlebars = require('handlebars')
+const path = require('path')
+
+/**
+ * Creates a helper that will stay same after being processed by Handlebars
+ *
+ * There are two Handlebars passes on the data :
+ *
+ * 1. At load time to create dummy data
+ * 2. When the data is being inserted so that we can reference data being created
+ *
+ * Since we need the `reference` helper to stay the same for the second pass, we
+ * create it with `passthroughHelper`.
+ *
+ * @param  {string}   name     - The name of the created helper
+ * @param  {function} callback - Callback to run when the helper is executed
+ * @return {string}            - A helper that when called will creates itself
+ *
+ * @example
+ * const reference = passthroughHelper('reference')
+ * Handlebars.registerHelper({ reference })
+ * const str = Handlebars.compile("{{ reference 'io.cozy.files' 0 '_id' }}")()
+ * > str = "{{ reference 'io.cozy.files' 0 '_id' }}"
+ */
+const passthroughHelper = function(name, callback) {
+  return function() {
+    callback && callback()
+    return new Handlebars.SafeString(
+      `{{ ${name} ${Array.from(arguments)
+        .slice(0, -1)
+        .map(singleQuoteString)
+        .join(' ')} }}`
+    )
+  }
+}
+
+const singleQuoteString = function(value) {
+  if (typeof value === 'string') {
+    return `'${value}'`
+  } else {
+    return value
+  }
+}
+
+module.exports = (handlebarsOptionsFile, options) => {
+  // dummy-json pass helpers
+  const turnOffParallelism = once(function() {
+    log.debug('Turning off parallelism since {{ reference }} helper is used.')
+    options.parallel = false
+  })
+
+  let handlebarsOptions = {
+    helpers: {
+      dir: passthroughHelper('dir'),
+      reference: passthroughHelper('reference', turnOffParallelism)
+    }
+  }
+
+  if (handlebarsOptionsFile) {
+    handlebarsOptions = merge(
+      handlebarsOptions,
+      require(path.resolve(`./${handlebarsOptionsFile}`))
+    )
+  }
+
+  return handlebarsOptions
+}

--- a/libs/parseDataFile.js
+++ b/libs/parseDataFile.js
@@ -1,0 +1,11 @@
+const dummyjson = require('dummy-json')
+const fs = require('fs')
+
+module.exports = (filepath, handlebarsOptions) => {
+  const template = fs.readFileSync(filepath, { encoding: 'utf8' })
+
+  // dummy-json pass passthrough helpers
+  const data = JSON.parse(dummyjson.parse(template, handlebarsOptions))
+
+  return data
+}

--- a/libs/utils.js
+++ b/libs/utils.js
@@ -151,3 +151,7 @@ module.exports.getWithInstanceLogger = function(client) {
     console.log.apply(console, args)
   }
 }
+
+module.exports.parseBool = function(boolString, defaultVal) {
+  return boolString === undefined ? defaultVal : boolString === 'true'
+}


### PR DESCRIPTION
When importing data using handlebars templates, we had errors like `SyntaxError: Unexpected token { in JSON at position 31` because we were trying to read the doctypes from the JSON file before transforming it.