### PR TITLE
feat: Recursively list scripts files

### DIFF
--- a/libs/scripts.js
+++ b/libs/scripts.js
@@ -37,12 +37,26 @@ const requireScript = scriptName => {
 
 /** List all builtin scripts */
 const list = () => {
-  const dir = path.join(__dirname, 'scripts')
-  return fs
-    .readdirSync(dir)
-    .filter(x => /\.js$/.exec(x))
-    .filter(x => !/\.spec\.js$/.exec(x))
-    .map(x => x.replace(/\.js$/, ''))
+  const walkDir = dir => {
+    let files = []
+    const dirContent = fs.readdirSync(dir)
+    dirContent.forEach(fileOrDir => {
+      const pathFileOrDir = path.join(dir, fileOrDir)
+      const stat = fs.statSync(pathFileOrDir)
+      if (stat && stat.isDirectory()) {
+        // Recursively walk in subdir
+        files = files.concat(walkDir(pathFileOrDir))
+      } else {
+        if (/\.js$/.exec(fileOrDir) && !/\.spec\.js$/.exec(fileOrDir)) {
+          const file = fileOrDir.replace(/\.js$/, '')
+          files.push(file)
+        }
+      }
+    })
+    return files
+  }
+  const dir = path.join(__dirname, '../scripts')
+  return walkDir(dir)
 }
 
 module.exports = {

--- a/libs/scripts.js
+++ b/libs/scripts.js
@@ -35,32 +35,34 @@ const requireScript = scriptName => {
   }
 }
 
+const walkDir = dir => {
+  let files = []
+  const dirContent = fs.readdirSync(dir)
+  dirContent.forEach(fileOrDir => {
+    const pathFileOrDir = path.join(dir, fileOrDir)
+    const stat = fs.statSync(pathFileOrDir)
+    if (stat && stat.isDirectory()) {
+      // Recursively walk in subdir
+      files = files.concat(walkDir(pathFileOrDir))
+    } else {
+      if (path.basename(dir) !== 'scripts') {
+        // Add dir basename for files in subdir
+        fileOrDir = path.join(path.basename(dir), fileOrDir)
+      }
+      files.push(fileOrDir)
+    }
+  })
+  return files
+}
+
 /** List all builtin scripts */
 const list = () => {
-  const walkDir = dir => {
-    let files = []
-    const dirContent = fs.readdirSync(dir)
-    dirContent.forEach(fileOrDir => {
-      const pathFileOrDir = path.join(dir, fileOrDir)
-      const stat = fs.statSync(pathFileOrDir)
-      if (stat && stat.isDirectory()) {
-        // Recursively walk in subdir
-        files = files.concat(walkDir(pathFileOrDir))
-      } else {
-        if (/\.js$/.exec(fileOrDir) && !/\.spec\.js$/.exec(fileOrDir)) {
-          let file = fileOrDir.replace(/\.js$/, '')
-          if (path.basename(dir) !== 'scripts') {
-            // Add dir basename for subdirectories
-            file = path.join(path.basename(dir), file)
-          }
-          files.push(file)
-        }
-      }
-    })
-    return files
-  }
   const dir = path.join(__dirname, '../scripts')
-  return walkDir(dir)
+  const files = walkDir(dir)
+  return files
+    .filter(f => /\.js$/.exec(f))
+    .filter(f => !/\.spec\.js$/.exec(f))
+    .map(f => f.replace(/\.js$/, ''))
 }
 
 module.exports = {

--- a/libs/scripts.js
+++ b/libs/scripts.js
@@ -48,7 +48,11 @@ const list = () => {
         files = files.concat(walkDir(pathFileOrDir))
       } else {
         if (/\.js$/.exec(fileOrDir) && !/\.spec\.js$/.exec(fileOrDir)) {
-          const file = fileOrDir.replace(/\.js$/, '')
+          let file = fileOrDir.replace(/\.js$/, '')
+          if (path.basename(dir) !== 'scripts') {
+            // Add dir basename for subdirectories
+            file = path.join(path.basename(dir), file)
+          }
           files.push(file)
         }
       }


### PR DESCRIPTION
The `ls-scripts` command was broken because it was looking for scripts in `libs/scripts/` instead of `scripts/`. Furthermore, it didn't list the scripts in sub-directories, such as `banking` or `contacts`.
This PR fix the command and make it recursive to list all the scripts, even in sub-directories.