### PR TITLE
Initialize cozy-client

### DIFF
--- a/libs/ACH.js
+++ b/libs/ACH.js
@@ -8,6 +8,7 @@ const cozyFetch = require('./cozyFetch')
 const log = require('./log')
 const request = require('request')
 const fs = require('fs')
+const { createClientInteractive } = require('cozy-client/dist/cli')
 
 const { handleBadToken } = require('../libs/utils')
 
@@ -42,16 +43,22 @@ class ACH {
     this.token = token || getTokenPath(url, doctypes)
   }
 
-  connect() {
+  async connect() {
     log.debug('Connecting to ' + this.url)
-    return getClient(this.token, this.url, this.doctypes)
-      .then(client => {
-        this.client = client
+    try {
+      /* NOTE: in the future, we expect to only use cozy-client */
+      this.client = await getClient(this.token, this.url, this.doctypes)
+      this.cozyClient = await createClientInteractive({
+        uri: this.url,
+        scope: this.doctypes,
+        oauth: {
+          softwareID: 'ACH'
+        }
       })
-      .catch(err => {
-        log.warn('Could not connect to' + this.url)
-        throw err
-      })
+    } catch (err) {
+      log.warn('Could not connect to' + this.url)
+      throw err
+    }
   }
 
   async downloadFile(id) {

--- a/libs/runBatch.spec.js
+++ b/libs/runBatch.spec.js
@@ -4,6 +4,10 @@ jest.mock('pouchdb-browser', () => () => {})
 jest.mock('./getClient', () => jest.fn())
 
 const CozyClient = require('cozy-client').default
+
+jest.mock('cozy-client/dist/cli')
+const { createClientInteractive } = require('cozy-client/dist/cli')
+
 const getClient = require('./getClient')
 const runBatch = require('./runBatch')
 
@@ -27,6 +31,7 @@ describe('batch', () => {
         _url: url
       }
     })
+    createClientInteractive.mockImplementation(async () => {})
   })
 
   const setup = () => {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "colors": "^1.3.3",
     "commander": "^2.19.0",
     "core-js": "3.0.0",
-    "cozy-client": "^13.6.0",
+    "cozy-client": "^13.20.0",
     "cozy-client-js": "^0.15.0",
     "cozy-doctypes": "1.39.0",
     "directory-tree": "^2.2.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2416,15 +2416,15 @@ cozy-client-js@^0.15.0:
     pouchdb-browser "7.0.0"
     pouchdb-find "7.0.0"
 
-cozy-client@^13.6.0:
-  version "13.6.0"
-  resolved "https://registry.yarnpkg.com/cozy-client/-/cozy-client-13.6.0.tgz#2d47944d6c5a5cb994a318f7ae7a080c7c925c95"
-  integrity sha512-ytSzywfdxPqhJ83BjcauTO3aPb7hB74J4ZIwxbRArAbxrnK1wJRl4TxEvdER2/Ht78dhACE5tqXNbEuMqYMtsQ==
+cozy-client@^13.20.0:
+  version "13.20.0"
+  resolved "https://registry.yarnpkg.com/cozy-client/-/cozy-client-13.20.0.tgz#307849253ed577e04e4271f2e45812765bb5e72e"
+  integrity sha512-uaIqis28V9PN7mHIL3Byqc5WuKW0957jPmyCvAHwXC9t6ydCclswOnNcIuhvXZ1HxTIpUjc7AU041eh1eqjrSw==
   dependencies:
     btoa "^1.2.1"
     cozy-device-helper "^1.7.3"
     cozy-logger "^1.6.0"
-    cozy-stack-client "^13.5.3"
+    cozy-stack-client "^13.16.0"
     isomorphic-fetch "^2.2.1"
     lodash "^4.17.13"
     microee "^0.0.6"
@@ -2470,10 +2470,10 @@ cozy-logger@^1.6.0:
     chalk "^2.4.2"
     json-stringify-safe "5.0.1"
 
-cozy-stack-client@^13.5.3:
-  version "13.5.3"
-  resolved "https://registry.yarnpkg.com/cozy-stack-client/-/cozy-stack-client-13.5.3.tgz#d8f2489becd6c8da5b558ec07c1c7bdfced35971"
-  integrity sha512-VpnDGeSjlmaoKOtM/b0tEbJgceQXdd9fyHn5/GkXUWfdhFazjNw8Tw4SOlF8cJC4keEhVw0oAdIgh4BhlJQ/Rg==
+cozy-stack-client@^13.16.0:
+  version "13.16.0"
+  resolved "https://registry.yarnpkg.com/cozy-stack-client/-/cozy-stack-client-13.16.0.tgz#e4e7043df34132dc6c1578b030d823e994a7e210"
+  integrity sha512-pAzBsB5pFL0wyccquLK4Hgw5uayMhoAVKJOThU+u+vYFpnYlNEZQ+iY9eFFOpQa47dWy0vTkmI0N0wk5chN/2g==
   dependencies:
     detect-node "^2.0.4"
     mime "^2.4.0"


### PR DESCRIPTION
In the future, we expect to migrate everything on cozy-client. As a
starting point, we add this initialization so new scripts can use
cozy-client.