### PR TITLE
feat: Process url CLI arg to remove -<app> if present

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -13,6 +13,7 @@ const scriptLib = require('./libs/scripts')
 const parseDataFile = require('./libs/parseDataFile')
 const getHandlebarsOptions = require('./libs/getHandlebarsOptions')
 const { parseBool } = require('./libs/utils')
+const urls = require('url')
 
 const DEFAULT_COZY_URL = 'http://cozy.tools:8080'
 
@@ -227,6 +228,24 @@ const autotoken = (url, doctypes) => {
   }
 }
 
+/**
+ * Removes the "app" part in a cozy URL
+ *
+ * This is useful for ergonomics as users often copy/paste an
+ * URL contaning the app
+ *
+ * input: https://moncozy-drive.mycozy.cloud
+ * ouput: https://moncozy.mycozy.cloud
+ */
+const parseCozyURL = stringUrl => {
+  const parsedUrl = urls.parse(stringUrl)
+  const splittedHost = parsedUrl.host.split('.')
+  parsedUrl.host = `${splittedHost[0].split('-')[0]}.${splittedHost
+    .slice(1)
+    .join('.')}`
+  return urls.format(parsedUrl)
+}
+
 // the CLI interface
 let program = require('commander')
 program
@@ -236,6 +255,7 @@ program
   .option(
     '-u --url [url]',
     `URL of the cozy to use. Defaults to "${DEFAULT_COZY_URL}".'`,
+    parseCozyURL,
     DEFAULT_COZY_URL
   )
 

--- a/libs/ACH.js
+++ b/libs/ACH.js
@@ -51,7 +51,7 @@ class ACH {
       this.oldClient = await getClient(this.token, this.url, this.doctypes)
       this.client = CozyClient.fromOldClient(this.oldClient)
     } catch (err) {
-      log.warn('Could not connect to' + this.url)
+      log.warn('Could not connect to ' + this.url)
       throw err
     }
   }


### PR DESCRIPTION
It is often the case when working with ACH that we copy/paste an URL
from the browser, from an app.

When this is the case the URL contains the app and ACH
did not handle this case. Now, ACH handles it gracefully and remove
the -<app> part if present.

Now we can do:

```
ach export --url https://mycozy-banks.mycozy.cloud io.cozy.contacts
```