### PR TITLE
fix: importDir uses the same structure as source directory

### DIFF
--- a/libs/utils.js
+++ b/libs/utils.js
@@ -78,12 +78,14 @@ const uploadFolderContent = (module.exports.uploadFolderContent = (
             return uploadFolderContent(client, child, folderDoc._id)
           } else {
             // it's a file
-            return uploadFile(client, child, folderDoc._id).then(fileDoc => {
-              console.log(
-                `  _id: ${fileDoc._id},  file.path: ${folderDoc.attributes.path}/${fileDoc.attributes.name}`
-              )
-              return fileDoc
-            })
+            return uploadFile(client, child, folderDoc.attributes.path).then(
+              fileDoc => {
+                console.log(
+                  `  _id: ${fileDoc._id},  file.path: ${folderDoc.attributes.path}/${fileDoc.attributes.name}`
+                )
+                return fileDoc
+              }
+            )
           }
         })
       )


### PR DESCRIPTION
Fixes #84

The files were uploaded with parent folder's id as path. So they were
not in the directory they belong to, but in a directory located at the
root and named after the real file's parent directory id.

This is fixed by  giving the parent folder's path instead of id to the
`uploadFile` function.