### PR TITLE
fix: Remove the slash trailing at the end of domain (fix autoToken)

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -243,8 +243,11 @@ const parseCozyURL = stringUrl => {
   parsedUrl.host = `${splittedHost[0].split('-')[0]}.${splittedHost
     .slice(1)
     .join('.')}`
-  return urls.format(parsedUrl)
+  // Using url module has a side effect: it adds a / at the end
+  // We remove it because it breaks make-token
+  return urls.format(parsedUrl).replace(/\/$/, '')
 }
+exports.parseCozyURL = parseCozyURL
 
 // the CLI interface
 let program = require('commander')

--- a/cli.spec.js
+++ b/cli.spec.js
@@ -1,0 +1,16 @@
+const cli = require('./cli')
+
+describe('cli', () => {
+  it('check if no trailing slash is present in url', async () => {
+    const urlIn = 'https://toto.mycozy.cloud'
+    expect(cli.parseCozyURL(urlIn)).toBe('https://toto.mycozy.cloud')
+  })
+  it('check if trailing slash is removed', async () => {
+    const urlIn = 'https://toto.mycozy.cloud/'
+    expect(cli.parseCozyURL(urlIn)).toBe('https://toto.mycozy.cloud')
+  })
+  it('check if app suffix is removed', async () => {
+    const urlIn = 'https://toto-drive.mycozy.cloud/'
+    expect(cli.parseCozyURL(urlIn)).toBe('https://toto.mycozy.cloud')
+  })
+})


### PR DESCRIPTION
This PR fix a dirty bug experienced since few months with latest version.

The helper add by Patrick to remove apps prefix in url (home-toto.mycozy.cloud become toto.mycozy.cloud) do not work as expected. It add a slash at the end of the string (as an compliant url). 
This side effect broke the make-token command. 
This fix simply remove it and keep the helper.