### PR TITLE
feat: Enable passing arguments to scripts

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -392,7 +392,10 @@ program
 
 program
   .command('script <scriptName>')
-  .arguments('[params...]', 'A list of parameters to be passed to the script')
+  .arguments(
+    '[params...]',
+    'A list of parameters to be passed to the script, separated by a space'
+  )
   .option('--autotoken', 'Automatically generate the permission token')
   .option('-x, --execute', 'Execute the script (disable dry run)')
   .option('-d, --doctypes', 'Print necessary doctypes (useful for automation)')


### PR DESCRIPTION
This PR allows passing a variable number of arguments.
These additionnal arguments are passed right after the file path of the script like so: `ACH script path/to/script.js arg1 arg2 ...`.

It is retrocompatible with every existing scripts.