### PR TITLE
feat: ParseCozyURL throw error if url doesn't start with `http`

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -247,6 +247,9 @@ const autotoken = (url, doctypes) => {
  * ouput: https://moncozy.mycozy.cloud
  */
 const parseCozyURL = stringUrl => {
+  if (!stringUrl.startsWith('http')) {
+    throw new Error('Cozy url must start with `http`')
+  }
   const parsedUrl = urls.parse(stringUrl)
   const splittedHost = parsedUrl.host.split('.')
   parsedUrl.host = `${splittedHost[0].split('-')[0]}.${splittedHost

--- a/cli.spec.js
+++ b/cli.spec.js
@@ -1,16 +1,31 @@
 const cli = require('./cli')
 
-describe('cli', () => {
+describe('parseCozyURL', () => {
   it('check if no trailing slash is present in url', async () => {
     const urlIn = 'https://toto.mycozy.cloud'
+
     expect(cli.parseCozyURL(urlIn)).toBe('https://toto.mycozy.cloud')
   })
+
   it('check if trailing slash is removed', async () => {
     const urlIn = 'https://toto.mycozy.cloud/'
+
     expect(cli.parseCozyURL(urlIn)).toBe('https://toto.mycozy.cloud')
   })
+
   it('check if app suffix is removed', async () => {
     const urlIn = 'https://toto-drive.mycozy.cloud/'
+
     expect(cli.parseCozyURL(urlIn)).toBe('https://toto.mycozy.cloud')
+  })
+
+  it("should throw an error if the url doesn't start with 'http'", async () => {
+    const cozyUrl = 'toto.mycozy.cloud'
+
+    try {
+      cli.parseCozyURL(cozyUrl)
+    } catch (e) {
+      expect(e.message).toMatch('Cozy url must start with `http`')
+    }
   })
 })


### PR DESCRIPTION
cas problématique : instance en local (donc http et non https) et oublie de le spécifier dans l'url "toto.cozy.localhost:8080"

Dans ce cas il y a un message d'erreur de parsing, sans trop qu'on sache pourquoi si on ne lit pas le code