### PR TITLE
feat: Add log to show --url

### DIFF
--- a/libs/ACH.js
+++ b/libs/ACH.js
@@ -52,6 +52,9 @@ class ACH {
       this.client = CozyClient.fromOldClient(this.oldClient)
     } catch (err) {
       log.warn('Could not connect to ' + this.url)
+      log.warn(
+        'You can specify the Cozy URL by using the --url argument: ACH --url http://bob.cozy.localhost:8080 '
+      )
       throw err
     }
   }


### PR DESCRIPTION
Add a log to show how to pass a specific
URL to ACH. No need to scroll down the
README anymore. The answer is now right
in front of us.