### PR TITLE
Fix: Make ACH work on Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,16 +211,17 @@ You can create photo albums from a folder on your disk.
 $ python scripts/albums-from-dir.py my-photos-directory resulting-albums.json
 ```
 
-### Export data keeping the ids
+### Export data removing the ids
 
-By default, `_id` and `_rev` are stripped from the exported data. Sometimes, you want to keep the ids/rev of the documents you export. Set the
-environment variable `ACH_KEEP_ID` to do so :
+By default, exported data contains all `_id`. Sometimes, you want to strip the ids from the documents you export. Set the
+environment variable `ACH_NO_KEEP_ID` to do so :
 
 ```bash
-env ACH_KEEP_ID=true ACH export io.cozy.bills --url https://isabelledurand.cozy.rocks ./bills.json
+env ACH_NO_KEEP_ID=true ACH export io.cozy.bills --url https://isabelledurand.cozy.rocks ./bills.json
 ```
 
-`ACH_KEEP_REV` does the same to keep the `_rev` field.
+Contrary to `_id`, `_rev` is stripped by default. To keep the `_rev` field, set the
+environment variable `ACH_KEEP_REV`.
 
 
 ### Import data from a CSV

--- a/README.md
+++ b/README.md
@@ -217,7 +217,7 @@ By default, `_id` and `_rev` are stripped from the exported data. Sometimes, you
 environment variable `ACH_KEEP_ID` to do so :
 
 ```bash
-env ACH_KEEP_ID=true ACH export io.cozy.bills --url https://isabelledurand.cozy.rocks /tmp/bills.json
+env ACH_KEEP_ID=true ACH export io.cozy.bills --url https://isabelledurand.cozy.rocks ./bills.json
 ```
 
 `ACH_KEEP_REV` does the same to keep the `_rev` field.

--- a/libs/ACH.js
+++ b/libs/ACH.js
@@ -10,6 +10,8 @@ const cozyFetch = require('./cozyFetch')
 const log = require('./log')
 const request = require('request')
 const fs = require('fs')
+const path = require('path')
+const os = require('os')
 
 const { handleBadToken } = require('../libs/utils')
 
@@ -34,7 +36,7 @@ const getTokenPath = function(url, doctypes) {
       .slice()
       .sort()
       .join(',')
-  return '/tmp/.ach-token-' + hashCode(key) + '.json'
+  return path.join(os.tmpdir(), '.ach-token-' + hashCode(key) + '.json')
 }
 
 class ACH {

--- a/libs/exportData.js
+++ b/libs/exportData.js
@@ -1,5 +1,6 @@
 const _ = require('lodash')
-const fs = require('fs').promises
+const fs = require('fs')
+const path = require('path')
 const log = require('./log')
 const { Q } = require('cozy-client')
 
@@ -81,7 +82,8 @@ module.exports = (cozyClient, doctypes, filename, last) => {
       if (filename === '-' || !filename) {
         console.log(json)
       } else {
-        return fs.writeFile(filename, json)
+        fs.mkdirSync(path.dirname(filename), { recursive: true })
+        return fs.promises.writeFile(filename, json)
       }
     })
 }

--- a/libs/getClient.js
+++ b/libs/getClient.js
@@ -129,7 +129,7 @@ exported.getClientWithTokenString = tokenString => async url => {
 
 // convenience wrapper around the 2 client getters
 module.exports = (tokenPath, cozyUrl, docTypes) => {
-  const absoluteTokenPath = tokenPath.startsWith('/')
+  const absoluteTokenPath = path.isAbsolute(tokenPath)
     ? tokenPath
     : path.join(process.cwd(), tokenPath)
 

--- a/libs/getClient.js
+++ b/libs/getClient.js
@@ -56,6 +56,7 @@ exported.getClientWithoutToken = tokenPath => (url, docTypes = []) => {
     cozyClient._token = new AppToken({ token })
 
     log.debug('Writing token file to ' + tokenPath)
+    fs.mkdirSync(path.dirname(tokenPath), { recursive: true })
     fs.writeFileSync(tokenPath, JSON.stringify({ token: token }), 'utf8')
 
     return revokeACHClients(cozyClient, {

--- a/libs/getClient.spec.js
+++ b/libs/getClient.spec.js
@@ -1,7 +1,8 @@
 const getClient = require('./getClient')
 
 jest.mock('fs', () => ({
-  existsSync: () => true
+  existsSync: () => true,
+  mkdirSync: jest.fn()
 }))
 
 describe('getClient', () => {

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
   "scripts": {
     "lint": "eslint '**/*.js'",
     "test": "jest",
-    "start": "node index.js",
+    "start": "node ./cli.js",
     "travis-deploy-once": "travis-deploy-once --pro",
     "semantic-release": "semantic-release"
   },


### PR DESCRIPTION
On Windows OS, `/tmp/` folder does not exist and may be considered as
relative path

To fix this we want to use `os.tmpdir()` to point to the OS specified
path for temp files

This modification change the macOS behavior as the used folder for
storing token is not `/tmp/` anymore but
`/var/folders/<SOME_UNIQUE_PATH>/T/` which is the per-user temporary
folder (see https://magnusviri.com/what-is-var-folders.html)

Fixes: #74

---

This PR also adds some securities in code to check that folders exist

---

This PR also improves project documentation and tooling