### PR TITLE
feat: Suggest adding domain to hosts file when connection fails

### DIFF
--- a/libs/ACH.js
+++ b/libs/ACH.js
@@ -57,6 +57,13 @@ class ACH {
       log.warn(
         'You can specify the Cozy URL by using the --url argument: ACH --url http://bob.cozy.localhost:8080 '
       )
+
+      if (this.url.includes('localhost')) {
+        log.warn(
+          `Seems like you are trying to connecto to a localhost server, please verify that this domain is declared in your system's hosts file (i.e. '127.0.0.1 bob.cozy.localhost')`
+        )
+      }
+
       throw err
     }
   }


### PR DESCRIPTION
When connecting to a local cozy-stack (i.e. `cozy.localhost:8080`), the user should configure their `hosts` file. Otherwise they will get an `getaddrinfo ENOTFOUND` error

People often get confused as their web browser success to access the local cozy-stack. But some web browsers have their internal domain resolution mechanism and so they may succeed to access the cozy-stack without the `hosts` entry. A terminal cannot do that

![image](https://user-images.githubusercontent.com/1884255/190369516-b5459192-fa79-48b1-ab17-43a52b250ded.png)
