### PR TITLE
feat: Add remove aggregation script

### DIFF
--- a/scripts/timeseries/removeAggregation.js
+++ b/scripts/timeseries/removeAggregation.js
@@ -1,0 +1,46 @@
+const { Q } = require('cozy-client')
+
+module.exports = {
+  getDoctypes: function() {
+    return ['io.cozy.timeseries.geojson']
+  },
+  /**
+   * FIXME: The params are an array passed to the scripts, here used to get the startDate
+   * This seems rather fragile, and cannot be documented in the CLI
+   * We need a better way to handle specific params for scripts
+   */
+
+  run: async function(ach, dryRun = true, params) {
+    const client = ach.client
+    if (dryRun) {
+      console.log('This is a dry run, no doc will be updated')
+    }
+
+    const fromDate = params.length > 0 ? params[0] : null
+
+    console.log(`Looking for docs with startDate above ${fromDate}`)
+    const query = Q('io.cozy.timeseries.geojson')
+      .where({
+        aggregation: { $exists: true },
+        startDate: {
+          $gt: fromDate
+        }
+      })
+      .limitBy(null)
+    const docs = await client.queryAll(query)
+    let newDocs = []
+    if (dryRun) {
+      console.log(`${docs.length} docs would be updated.`)
+      return
+    }
+    console.log(`Remove ${docs.length} aggregation from timeseries...`)
+    for (const doc of docs) {
+      delete doc.aggregation
+      newDocs.push(doc)
+    }
+    if (newDocs.length > 0) {
+      await client.saveAll(newDocs)
+    }
+    console.log('Done!')
+  }
+}


### PR DESCRIPTION
This is useful to test the aggregation service or to fix some mistakes.

Note the generic script parameter system seems rather fragile and is not really satisfying at this moment: any script called through `ACH script <path>` can get a `param`, which is an array of arguments passed to the script.
For example, by calling `ACH script timeseries/removeAggregations.js 2023-09-10`, the date will be in `params[0]`. But then, the caller of the script has no way to know this rather than reading the code...
