### PR TITLE
feat: Add missing `captureDevice` property to timeseries fixtures

### DIFF
--- a/data/timeseries/geojson-01.js
+++ b/data/timeseries/geojson-01.js
@@ -14,6 +14,7 @@ const getGeojson01 = (dates = geoJson01Dates) => {
     source: 'agremob.com',
     startDate: dates.startDate,
     endDate: dates.endDate,
+    captureDevice: 'test',
     series: [
       {
         features: [

--- a/data/timeseries/geojson-02.js
+++ b/data/timeseries/geojson-02.js
@@ -24,6 +24,7 @@ const getGeojson02 = (dates = geoJson02Dates) => {
     source: 'agremob.com',
     startDate: dates.startDate,
     endDate: dates.endDate,
+    captureDevice: 'test',
     series: [
       {
         features: [

--- a/data/timeseries/geojson-03.js
+++ b/data/timeseries/geojson-03.js
@@ -30,6 +30,7 @@ const getGeojson03 = (dates = geoJson03Dates) => {
     source: 'agremob.com',
     startDate: dates.startDate,
     endDate: dates.endDate,
+    captureDevice: 'test',
     series: [
       {
         type: 'FeatureCollection',


### PR DESCRIPTION
Cette propriété existe sur les timeseries réelles et est égale au `io.cozy.accounts.auth.login`