### PR TITLE
feat: Improve generateFiles command to create qualified files

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,9 @@ Automated Cozy Hydrater (ACH *[ax]*) is a CLI that lets you **request, create an
   + [Import data](#import-data)
   + [Import repositories with files](#import-repositories-with-files)
   + [Create photo albums with ACH](#create-photo-albums-with-ach)
-  + [Export data keeping the ids](#export-data-keeping-the-ids)
-  + [How to export all data from a konnector](#how-to-export-all-data-from-a-konnector)
+  + [Export data removing the ids](#export-data-removing-the-ids)
+  + [Import data from a CSV](#Import-data-from-a-CSV)
+  + [Generate some files](#Generate-some-files)
   + [Generate some qualified files with referenced contacts (mespapiers)](#Generate-some-papers)
 
 ## Install
@@ -39,7 +40,7 @@ Options:
 Commands:
   import <filepath> [handlebarsOptionsFile]   The file containing the JSON data to import. Defaults to "example-data.json". If the file doesn't exist in the application, ACH will try to find it inside its data folder. Then the dummy helpers JS file (optional).
   importDir <directoryPath>                   The path to the directory content to import. Defaults to "./DirectoriesToInject".
-  generateFiles [path] [filesCount]           Generates a given number of small files.
+  generateFiles [filesCount] [dirId]          Generates a given number of small files. (optional dirId)
   drop [options] <doctypes...>                Deletes all documents of the provided doctypes. For real.
   export <doctypes> [filename]                Exports data from the doctypes (separated by commas) to filename
   downloadFile <fileid>                       Download the file
@@ -227,6 +228,17 @@ environment variable `ACH_KEEP_REV`.
 ### Import data from a CSV
 
 See the [example](./examples/data-from-csv/README.md).
+
+### Generate some files
+
+To create files into a Cozy, use the `generateFiles` command:
+
+```shell
+$ ACH generateFiles 10 <id of directory> # by default will be at the root of your Drive
+```
+Options:
+- `-q`/`--qualify`: In order to have a random qualification on your files
+- `-m`/`--mime`: In order to change the default mime of files (`text/plain`)
 
 ### Generate some papers
 (usefull for MesPapiers)

--- a/cli.js
+++ b/cli.js
@@ -83,12 +83,12 @@ const handleImportDirCommand = async args => {
 }
 
 const handleGenerateFilesCommand = async args => {
-  const { path = '/', filesCount = 10, url, token } = args
+  const { dirId = 'io.cozy.files.root-dir', filesCount = 10, url, token } = args
   const ach = new ACH(token || autotoken(url, ['io.cozy.files']), url, [
     'io.cozy.files'
   ])
   await ach.connect()
-  await ach.createFiles(path, parseInt(filesCount))
+  await ach.createFiles(parseInt(filesCount), dirId)
 }
 
 const handleDropCommand = async args => {
@@ -321,14 +321,14 @@ program
   )
 
 program
-  .command('generateFiles [path] [filesCount]')
+  .command('generateFiles [filesCount] [dirId]')
   .description('Generates a given number of small files.')
   .action(
-    handleErrors(async function(path, filesCount) {
+    handleErrors(async function(filesCount, dirId) {
       await handleGenerateFilesCommand({
         url: program.url,
         token: program.token,
-        path,
+        dirId,
         filesCount
       })
     })

--- a/cli.js
+++ b/cli.js
@@ -83,12 +83,31 @@ const handleImportDirCommand = async args => {
 }
 
 const handleGenerateFilesCommand = async args => {
-  const { dirId = 'io.cozy.files.root-dir', filesCount = 10, url, token } = args
+  const {
+    dirId = 'io.cozy.files.root-dir',
+    filesCount = 10,
+    url,
+    token,
+    qualify,
+    mime = 'text/plain'
+  } = args
+
+  if (qualify && !token) {
+    log.warn(
+      'To view files in MyPapers, an app/konnector token is required to create qualified files.\nThis token allows you to have the `cozyMetadata.createdByApp` prop on files.'
+    )
+  }
+
   const ach = new ACH(token || autotoken(url, ['io.cozy.files']), url, [
     'io.cozy.files'
   ])
   await ach.connect()
-  await ach.createFiles(parseInt(filesCount), dirId)
+  await ach.createFiles({
+    filesCount: parseInt(filesCount),
+    dirId,
+    qualify,
+    mime
+  })
 }
 
 const handleDropCommand = async args => {
@@ -322,14 +341,17 @@ program
 
 program
   .command('generateFiles [filesCount] [dirId]')
+  .option('-q, --qualify', 'Add qualification to the files')
+  .option('-m, --mime <s>', 'Create files with this mime type')
   .description('Generates a given number of small files.')
   .action(
-    handleErrors(async function(filesCount, dirId) {
+    handleErrors(async function(filesCount, dirId, options) {
       await handleGenerateFilesCommand({
         url: program.url,
         token: program.token,
+        filesCount,
         dirId,
-        filesCount
+        ...options
       })
     })
   )

--- a/libs/ACH.js
+++ b/libs/ACH.js
@@ -121,7 +121,7 @@ const methods = {
   },
   createFiles: {
     method: createFiles,
-    oldClient: true
+    oldClient: false
   },
   export: {
     method: exportDocs,

--- a/libs/createFiles.js
+++ b/libs/createFiles.js
@@ -1,16 +1,26 @@
 const ProgressBar = require('progress')
 const faker = require('faker')
+const {
+  uploadFileWithConflictStrategy
+} = require('cozy-client/dist/models/file')
 
-module.exports = async (client, path, filesCount) => {
-  const { forceCreateByPath } = client.files
-
+module.exports = async (
+  client,
+  filesCount,
+  dirId = 'io.cozy.files.root-dir'
+) => {
   const bar = new ProgressBar(':bar', { total: filesCount })
 
   for (let i = 0; i < filesCount; i++) {
-    const name = faker.datatype.uuid()
-    await forceCreateByPath(`${path}/${name}.txt`, name, {
-      name: `${name}.txt`,
-      contentType: 'text/plain'
+    const name = faker.lorem.word()
+    const content = faker.lorem.paragraph()
+    const buffer = new Buffer.from(content, 'utf-8')
+
+    await uploadFileWithConflictStrategy(client, buffer.toString(), {
+      name,
+      dirId,
+      contentType: 'text/plain',
+      conflictStrategy: 'rename'
     })
     bar.tick()
   }


### PR DESCRIPTION
En l'état, les changements apportés par cette PR conserve le fonctionnement de la commande `generateFiles` mais vont aussi lui permettre de générer des fichiers qualifiés (avec les qualifications existantes sur cozy-client)

Info importante, certaines apps comme MesPapiers fetch les fichiers qualifiés mais qui doivent aussi avoir la prop `cozyMetadata.createdByApp`.
La création via ACH retourne bien des fichiers qualifiés mais sans cette prop, pour l'avoir il suffit de générer un token d'app/connecteur (le token de l'app où vous souhaitez voir les fichiers semble bien) et de le passer à ACH via l'option `-t`.